### PR TITLE
Add start script for running app with virtual environment

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e
+
+# Determine the directory of this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Path to the virtual environment
+VENV_PATH="$SCRIPT_DIR/path/to/venv"
+
+if [ ! -d "$VENV_PATH" ]; then
+  echo "Virtual environment not found at $VENV_PATH" >&2
+  exit 1
+fi
+
+# Activate the virtual environment
+source "$VENV_PATH/bin/activate"
+
+# Run the application
+exec python "$SCRIPT_DIR/app.py"


### PR DESCRIPTION
## Summary
- add `start.sh` to activate `path/to/venv` and run `app.py`

## Testing
- `bash -n start.sh`
- `./start.sh >/tmp/app.log 2>&1 &`

------
https://chatgpt.com/codex/tasks/task_b_68bc45ad176c832289c52f791f1a81c4